### PR TITLE
Adjust `viewerContainer` top offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Enhancements:
 
 * Add cursor tools for enrichments, and box select.
 
+Bug Fixes:
+
+* Repair some layout issues with the URL bar at top of display area.
+
 ## 3.1.1 (221202)
 
 * Add a release procedure, and begin publishing release branches.

--- a/web/aux.css
+++ b/web/aux.css
@@ -27,6 +27,10 @@
   margin-left: 6px;
 }
 
+.pfsc-ise-pdf #viewerContainer {
+  top: 64px;
+}
+
 .themeDark #URL {
   color: #222;
 }


### PR DESCRIPTION
Now taking the URL bar into account. This repairs issues we were having, with autoscroll appearing to scroll a little bit too high.